### PR TITLE
change tray clicking behavior on Windows

### DIFF
--- a/apps/plumeimpactor/src/subscriptions.rs
+++ b/apps/plumeimpactor/src/subscriptions.rs
@@ -89,9 +89,10 @@ pub(crate) fn tray_subscription() -> Subscription<Message> {
                             let _ = tx.unbounded_send(Message::TrayMenuClicked(event.id));
                         }
 
+                        #[cfg(target_os = "windows")]
                         if let Ok(event) = tray_channel.try_recv() {
                             match event {
-                                TrayIconEvent::DoubleClick {
+                                TrayIconEvent::Click {
                                     button: tray_icon::MouseButton::Left,
                                     ..
                                 } => {

--- a/apps/plumeimpactor/src/tray.rs
+++ b/apps/plumeimpactor/src/tray.rs
@@ -5,12 +5,17 @@ use tray_icon::{
 
 pub(crate) fn build_tray_icon(menu: &Menu) -> TrayIcon {
     let icon = load_icon();
-    tray_icon::TrayIconBuilder::new()
+    let mut builder = tray_icon::TrayIconBuilder::new()
         .with_menu(Box::new(menu.clone()))
         .with_tooltip(crate::APP_NAME)
-        .with_icon(icon)
-        .build()
-        .expect("Failed to build tray icon")
+        .with_icon(icon);
+
+    #[cfg(target_os = "windows")]
+    {
+        builder = builder.with_menu_on_left_click(false);
+    }
+
+    builder.build().expect("Failed to build tray icon")
 }
 
 fn load_icon() -> tray_icon::Icon {


### PR DESCRIPTION
Essentially just #75 again. Does touch on Linux/MacOS behavior currently as direct clicks were made Windows only.
> The tray icon now opens the main window on a left-click and the context menu on a right-click, aligning more closely with "standard" Windows behavior.

Feel free to close if this is not something you want.