### PR TITLE
fix: bundle name may be stripped to empty string

### DIFF
--- a/crates/plume_types/src/bundle.rs
+++ b/crates/plume_types/src/bundle.rs
@@ -168,6 +168,10 @@ impl PlistInfoTrait for Bundle {
         get_plist_string!(self, "CFBundleIdentifier")
     }
 
+    fn get_bundle_name(&self) -> Option<String> {
+        get_plist_string!(self, "CFBundleName")
+    }
+
     fn get_version(&self) -> Option<String> {
         get_plist_string!(self, "CFBundleShortVersionString")
     }

--- a/crates/plume_types/src/lib.rs
+++ b/crates/plume_types/src/lib.rs
@@ -60,6 +60,7 @@ pub trait PlistInfoTrait {
     fn get_name(&self) -> Option<String>;
     fn get_executable(&self) -> Option<String>;
     fn get_bundle_identifier(&self) -> Option<String>;
+    fn get_bundle_name(&self) -> Option<String>;
     fn get_version(&self) -> Option<String>;
     fn get_build_version(&self) -> Option<String>;
 }

--- a/crates/plume_types/src/package.rs
+++ b/crates/plume_types/src/package.rs
@@ -166,6 +166,10 @@ impl PlistInfoTrait for Package {
         get_plist_dict_value!(self, "CFBundleIdentifier")
     }
 
+    fn get_bundle_name(&self) -> Option<String> {
+        get_plist_dict_value!(self, "CFBundleName")
+    }
+
     fn get_version(&self) -> Option<String> {
         get_plist_dict_value!(self, "CFBundleShortVersionString")
     }

--- a/crates/plume_types/src/signer.rs
+++ b/crates/plume_types/src/signer.rs
@@ -208,10 +208,7 @@ impl Signer {
                     .get_bundle_identifier()
                     .ok_or_else(|| Error::Other("Failed to get bundle identifier.".into()))?;
 
-                let name = sub_bundle
-                    .get_bundle_name()
-                    .or_else(|| id.split('.').last().map(|s| s.to_string()))
-                    .ok_or_else(|| Error::Other("Failed to get bundle name.".into()))?;
+                let name = sub_bundle.get_bundle_name().unwrap_or_else(|| id.clone());
 
                 session.qh_ensure_app_id(&team_id, &name, &id).await?;
 

--- a/crates/plume_types/src/signer.rs
+++ b/crates/plume_types/src/signer.rs
@@ -208,9 +208,12 @@ impl Signer {
                     .get_bundle_identifier()
                     .ok_or_else(|| Error::Other("Failed to get bundle identifier.".into()))?;
 
-                session
-                    .qh_ensure_app_id(&team_id, &sub_bundle.get_name().unwrap_or_default(), &id)
-                    .await?;
+                let name = sub_bundle
+                    .get_bundle_name()
+                    .or_else(|| id.split('.').last().map(|s| s.to_string()))
+                    .ok_or_else(|| Error::Other("Failed to get bundle name.".into()))?;
+
+                session.qh_ensure_app_id(&team_id, &name, &id).await?;
 
                 let app_id_id = session
                     .qh_get_app_id(&team_id, &id)


### PR DESCRIPTION
`get_name()` retrieves the display name first. Some apps may use CJK characters for the display name, this will be stripped to an empty string when calling `qh_add_app_id()`,  and resulting in an API error.