### PR TITLE
Update platform_specific settings for non-macos

### DIFF
--- a/apps/plumeimpactor/src/defaults.rs
+++ b/apps/plumeimpactor/src/defaults.rs
@@ -25,11 +25,14 @@ pub(crate) fn default_window_settings() -> window::Settings {
         ..Default::default()
     };
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     let platform_specific = window::settings::PlatformSpecific {
         application_id: String::from("dev.khcrysalis.PlumeImpactor"),
         ..Default::default()
     };
+
+    #[cfg(target_os = "windows")]
+    let platform_specific = window::settings::PlatformSpecific::default();
 
     window::Settings {
         size: iced::Size::new(575.0, 410.0),


### PR DESCRIPTION
With this change I was able to get the window icon to appear both in the titlebar and in the taskbar

With this change:
<img width="1003" height="650" alt="Screenshot_20260128_142725" src="https://github.com/user-attachments/assets/97313401-614b-4855-a29e-6eeeb8d390c2" />

Without this change:
<img width="934" height="568" alt="Screenshot_20260128_143713" src="https://github.com/user-attachments/assets/7eee5af9-2179-4982-8730-f4ec60a917b1" />

The explanation is that Iced doesn't yet seem to support the [xdg-toplevel-icon-v1](https://wayland.app/protocols/xdg-toplevel-icon-v1) protocol, so in order to give icons to the window the way to do that for now is to give the app an application_id and make it match with the .desktop file, and since I've seen that in the flatpak .desktop file it calls it "dev.khcrysalis.PlumeImpactor", then I just gave the same name to the application_id and now the icon works both on the titlebar and the taskbar.

I think this should fix https://github.com/khcrysalis/Impactor/issues/100 at least for the flatpak version where it automatically installs a .desktop file.