### PR TITLE
chore: replace winres with winresource (maintained fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,7 +5261,7 @@ dependencies = [
  "tokio",
  "tray-icon",
  "uuid",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -6425,6 +6425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7201,23 +7210,29 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -7257,7 +7272,7 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -7282,6 +7297,12 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow 0.7.13",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -8801,11 +8822,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winres"
-version = "0.1.11"
-source = "git+https://github.com/Nilstrieb/winres?branch=linking-flags#c839134b5f78d7dd0f5c8211ec6c7b675b0026fc"
+name = "winresource"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
 dependencies = [
- "toml 0.5.11",
+ "toml 0.9.11+spec-1.1.0",
  "version_check",
 ]
 

--- a/apps/plumeimpactor/Cargo.toml
+++ b/apps/plumeimpactor/Cargo.toml
@@ -37,7 +37,7 @@ auto-launcher = "0.6.1"
 plume_gestalt = { path = "../../crates/plume_gestalt" }
 
 [build-dependencies]
-winres = { git = "https://github.com/Nilstrieb/winres", branch = "linking-flags" }
+winresource = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/apps/plumeimpactor/build.rs
+++ b/apps/plumeimpactor/build.rs
@@ -1,5 +1,5 @@
 use std::io;
-use winres::WindowsResource;
+use winresource::WindowsResource;
 
 fn main() -> io::Result<()> {
     if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "windows" {


### PR DESCRIPTION
Hi, I hope this PR could be useful :)

---

winres is pretty much deprecated; winresource seems to be the main maintained fork as of now

this PR removes the need for a patched winres (`winres = { git = "https://github.com/Nilstrieb/winres", branch = "linking-flags" }`) as winresource includes the rust 1.61 fix

winresource also seems to be the preferred crate by microsoft employees (https://github.com/microsoft/edit/blob/main/crates/edit/Cargo.toml)

The build job runs fine
https://github.com/mq1/Impactor/actions/runs/21689433468/job/62545117029


ps: congrats on the 1k stars! ⭐️