### PR TITLE
fix: add StartupWMClass to .desktop file

### DIFF
--- a/package/linux/dev.khcrysalis.PlumeImpactor.desktop
+++ b/package/linux/dev.khcrysalis.PlumeImpactor.desktop
@@ -9,3 +9,4 @@ Categories=Utility;
 Icon=dev.khcrysalis.PlumeImpactor
 Exec=plumeimpactor
 Terminal=false
+StartupWMClass=dev.khcrysalis.PlumeImpactor


### PR DESCRIPTION
i noticed in #99 that kde plasma displays the generic wayland app icon in the title bar, this PR should fix that