### PR TITLE
feat: add nix dev shell flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.flatpak-builder
 /.flatpak-out
 /shared-modules
+/.direnv
 
 *.DS_Store
 state.plist

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1775099554,
+        "narHash": "sha256-3xBsGnGDLOFtnPZ1D3j2LU19wpAlYefRKTlkv648rU0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8d6387ed6d8e6e6672fd3ed4b61b59d44b124d99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+	inputs = {
+		nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+		rust-overlay.url = "github:oxalica/rust-overlay";
+	};
+
+	outputs = {
+		self,
+		nixpkgs,
+		rust-overlay,
+		...
+	}: let
+		inherit (nixpkgs) lib;
+		inherit (lib.attrsets) genAttrs;
+		inherit (lib.systems) flakeExposed;
+		overlays = [(import rust-overlay)];
+
+		forAllSystems = fn:
+			genAttrs flakeExposed (
+				system:
+					fn (
+						import nixpkgs {
+							inherit system overlays;
+							config.allowUnfree = true;
+						}
+					)
+			);
+	in {
+		devShells =
+			forAllSystems (pkgs: {
+					default =
+						pkgs.mkShell {
+							nativeBuildInputs = with pkgs; [
+								pkg-config
+								gtk3
+								libayatana-appindicator
+								libappindicator
+							];
+							buildInputs = with pkgs; [
+								nixd
+								(rust-bin.stable.latest.default.override {
+										extensions = ["rust-src" "rust-analyzer"];
+									})
+							];
+							shellHook = with pkgs; ''
+								export LD_LIBRARY_PATH="${lib.makeLibraryPath [
+									libayatana-appindicator
+									libappindicator
+								]}:$LD_LIBRARY_PATH"
+							'';
+						};
+				});
+	};
+}


### PR DESCRIPTION
this adds a nix dev shell flake and direnv so that you can easily make a reproducible compilation environment without modifying your host system at all

install direnv and then just type `direnv allow`, then you are in the shell

there are no changes to app functionality, it works identically, this is just for convenience