### PR TITLE
fix: generate valid app group identifiers from resigned bundle ID

### DIFF
--- a/crates/plume_utils/src/signer.rs
+++ b/crates/plume_utils/src/signer.rs
@@ -290,15 +290,22 @@ impl Signer {
                 }
 
                 if let Some(app_groups) = macho.app_groups_for_entitlements() {
-                    let mut app_group_ids: Vec<String> = Vec::new();
-                    for group in &app_groups {
-                        let mut group_name = format!("{group}.{team_id}");
+                    let group_names: Vec<String> = app_groups
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| {
+                            if app_groups.len() == 1 {
+                                format!("group.{id}")
+                            } else {
+                                format!("group.{id}.{i}")
+                            }
+                        })
+                        .collect();
 
-                        if is_refresh {
-                            group_name = group.clone();
-                        }
+                    let mut app_group_ids: Vec<String> = Vec::new();
+                    for group_name in &group_names {
                         let group_id = session
-                            .qh_ensure_app_group(&team_id, &group_name, &group_name)
+                            .qh_ensure_app_group(&team_id, group_name, group_name)
                             .await?;
                         app_group_ids.push(group_id.application_group);
                     }
@@ -309,9 +316,9 @@ impl Signer {
                             bundle.set_info_plist_key(
                                 "ALTAppGroups",
                                 Value::Array(
-                                    app_groups
+                                    group_names
                                         .iter()
-                                        .map(|s| Value::String(format!("{s}.{team_id}")))
+                                        .map(|s| Value::String(s.clone()))
                                         .collect(),
                                 ),
                             )?;


### PR DESCRIPTION
## Problem

When signing IPAs whose entitlements contain `com.apple.security.application-groups` values that don't start with `group.` (e.g. FilzaJailed uses `com.tigisoftware.sharedfiles`), the Apple Developer API returns:

1. **"Application Group identifiers should start with 'group.'"** — the raw entitlement value was used directly without adding the required `group.` prefix
2. **"An Application Group with Identifier '...' is not available"** — even with the prefix added, using another developer's namespace (e.g. `group.com.tigisoftware.sharedfiles.TEAMID`) is rejected by Apple

## Fix

Construct app group identifiers from the resigned bundle ID instead of the original entitlement value. For example:

- **Before:** `com.tigisoftware.sharedfiles.XP38UQ85XJ` (invalid — no `group.` prefix, foreign namespace)
- **After:** `group.com.tigisoftware.Filza.XP38UQ85XJ` (valid — proper prefix, uses resigned bundle ID which is unique to the signing account)

For apps with multiple app groups, a numeric suffix is appended (e.g. `group.{id}.0`, `group.{id}.1`).

## Changes

- `crates/plume_utils/src/signer.rs` — 1 file changed, 16 insertions, 9 deletions