### PR TITLE
Fix username handling in SRP verifier process

### DIFF
--- a/crates/plume_core/src/auth/account/login.rs
+++ b/crates/plume_core/src/auth/account/login.rs
@@ -179,7 +179,7 @@ impl Account {
         )?;
 
         let verifier = srp_client
-            .process_reply(&a, username.as_bytes(), &password_buf, salt, b_pub)
+            .process_reply(&a, username_for_spd.as_bytes(), &password_buf, salt, b_pub)
             .unwrap();
 
         let challenge_body = ChallengeRequestBody {


### PR DESCRIPTION
There is an issue where the application fails to authenticate an account if the email address contains uppercase letters. Even when the password is correct, the application returns a login error or crashes unless the email is entered entirely in lowercase.

Fix was swapping `username.as_bytes()` with `username_for_spd.as_bytes()`

I didn't tested it.