### PR TITLE
feat: grow installer window and fix tweak row overflow

### DIFF
--- a/apps/plumeimpactor/src/defaults.rs
+++ b/apps/plumeimpactor/src/defaults.rs
@@ -7,20 +7,6 @@ use iced::window;
 
 use crate::appearance;
 
-pub(crate) const WINDOW_WIDTH: f32 = 575.0;
-pub(crate) const WINDOW_HEIGHT: f32 = 410.0;
-// The installer screen packs in a lot more content (package info, options,
-// tweaks, etc.), so it gets a taller window to avoid forcing the user to scroll.
-pub(crate) const INSTALLER_WINDOW_HEIGHT: f32 = 485.0;
-
-pub(crate) fn default_window_size() -> iced::Size {
-    iced::Size::new(WINDOW_WIDTH, WINDOW_HEIGHT)
-}
-
-pub(crate) fn installer_window_size() -> iced::Size {
-    iced::Size::new(WINDOW_WIDTH, INSTALLER_WINDOW_HEIGHT)
-}
-
 pub(crate) fn default_settings() -> iced::Settings {
     iced::Settings {
         default_font: appearance::p_font(),
@@ -49,7 +35,8 @@ pub(crate) fn default_window_settings() -> window::Settings {
     let platform_specific = window::settings::PlatformSpecific::default();
 
     window::Settings {
-        size: default_window_size(),
+        // Sized to fit the installer screen (the tallest) without scrolling.
+        size: iced::Size::new(575.0, 475.0),
         position: window::Position::Centered,
         exit_on_close_request: false,
         resizable: false,

--- a/apps/plumeimpactor/src/defaults.rs
+++ b/apps/plumeimpactor/src/defaults.rs
@@ -7,6 +7,20 @@ use iced::window;
 
 use crate::appearance;
 
+pub(crate) const WINDOW_WIDTH: f32 = 575.0;
+pub(crate) const WINDOW_HEIGHT: f32 = 410.0;
+// The installer screen packs in a lot more content (package info, options,
+// tweaks, etc.), so it gets a taller window to avoid forcing the user to scroll.
+pub(crate) const INSTALLER_WINDOW_HEIGHT: f32 = 485.0;
+
+pub(crate) fn default_window_size() -> iced::Size {
+    iced::Size::new(WINDOW_WIDTH, WINDOW_HEIGHT)
+}
+
+pub(crate) fn installer_window_size() -> iced::Size {
+    iced::Size::new(WINDOW_WIDTH, INSTALLER_WINDOW_HEIGHT)
+}
+
 pub(crate) fn default_settings() -> iced::Settings {
     iced::Settings {
         default_font: appearance::p_font(),
@@ -35,7 +49,7 @@ pub(crate) fn default_window_settings() -> window::Settings {
     let platform_specific = window::settings::PlatformSpecific::default();
 
     window::Settings {
-        size: iced::Size::new(575.0, 410.0),
+        size: default_window_size(),
         position: window::Position::Centered,
         exit_on_close_request: false,
         resizable: false,

--- a/apps/plumeimpactor/src/screen/mod.rs
+++ b/apps/plumeimpactor/src/screen/mod.rs
@@ -94,7 +94,6 @@ pub struct Impactor {
     pending_installation: bool,
     certificate_reset_queue: VecDeque<crate::certificate_reset::ConfirmationRequest>,
     selected_locale: Option<String>,
-    current_window_size: iced::Size,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -146,7 +145,6 @@ impl Impactor {
                 pending_installation: false,
                 certificate_reset_queue: VecDeque::new(),
                 selected_locale,
-                current_window_size: defaults::default_window_size(),
             },
             open_task,
         )
@@ -170,32 +168,6 @@ impl Impactor {
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
-        let task = self.update_inner(message);
-        Task::batch([task, self.sync_window_size()])
-    }
-
-    // Resizes the main window to fit the current screen. The installer screen
-    // needs more vertical space, so the window grows when entering it and
-    // shrinks back when leaving.
-    fn sync_window_size(&mut self) -> Task<Message> {
-        let Some(id) = self.main_window else {
-            return Task::none();
-        };
-
-        let desired = match self.current_screen {
-            ImpactorScreen::Installer(_) => defaults::installer_window_size(),
-            _ => defaults::default_window_size(),
-        };
-
-        if desired == self.current_window_size {
-            return Task::none();
-        }
-
-        self.current_window_size = desired;
-        window::resize(id, desired)
-    }
-
-    fn update_inner(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::ComboBoxSelected(value) => {
                 self.selected_device = self
@@ -412,7 +384,6 @@ impl Impactor {
                 } else {
                     let (id, open_task) = window::open(defaults::default_window_settings());
                     self.main_window = Some(id);
-                    self.current_window_size = defaults::default_window_size();
                     open_task.discard()
                 }
             }

--- a/apps/plumeimpactor/src/screen/mod.rs
+++ b/apps/plumeimpactor/src/screen/mod.rs
@@ -94,6 +94,7 @@ pub struct Impactor {
     pending_installation: bool,
     certificate_reset_queue: VecDeque<crate::certificate_reset::ConfirmationRequest>,
     selected_locale: Option<String>,
+    current_window_size: iced::Size,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -145,6 +146,7 @@ impl Impactor {
                 pending_installation: false,
                 certificate_reset_queue: VecDeque::new(),
                 selected_locale,
+                current_window_size: defaults::default_window_size(),
             },
             open_task,
         )
@@ -168,6 +170,32 @@ impl Impactor {
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
+        let task = self.update_inner(message);
+        Task::batch([task, self.sync_window_size()])
+    }
+
+    // Resizes the main window to fit the current screen. The installer screen
+    // needs more vertical space, so the window grows when entering it and
+    // shrinks back when leaving.
+    fn sync_window_size(&mut self) -> Task<Message> {
+        let Some(id) = self.main_window else {
+            return Task::none();
+        };
+
+        let desired = match self.current_screen {
+            ImpactorScreen::Installer(_) => defaults::installer_window_size(),
+            _ => defaults::default_window_size(),
+        };
+
+        if desired == self.current_window_size {
+            return Task::none();
+        }
+
+        self.current_window_size = desired;
+        window::resize(id, desired)
+    }
+
+    fn update_inner(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::ComboBoxSelected(value) => {
                 self.selected_device = self
@@ -384,6 +412,7 @@ impl Impactor {
                 } else {
                     let (id, open_task) = window::open(defaults::default_window_settings());
                     self.main_window = Some(id);
+                    self.current_window_size = defaults::default_window_size();
                     open_task.discard()
                 }
             }

--- a/apps/plumeimpactor/src/screen/package.rs
+++ b/apps/plumeimpactor/src/screen/package.rs
@@ -512,14 +512,15 @@ impl PackageScreen {
                 let tweak_row = row![
                     text(tweak.file_name().and_then(|n| n.to_str()).unwrap_or("???"))
                         .size(12)
-                        .width(Fill),
+                        .width(Fill)
+                        .wrapping(text::Wrapping::WordOrGlyph),
                     button(appearance::icon(appearance::MINUS))
                         .on_press(Message::RemoveTweak(i))
                         .style(appearance::s_button)
                         .padding(6)
                 ]
                 .spacing(8)
-                .align_y(Alignment::Center);
+                .align_y(Alignment::Start);
 
                 tweak_list = tweak_list.push(tweak_row);
             }


### PR DESCRIPTION
This PR polishes the installer (package options) screen.

- The window now grows taller when entering the installer screen and shrinks back when leaving it, so the buttons and options fit initially without scrolling. Other screens keep their original size.
- Long tweak filenames now wrap within their column instead of running underneath the remove (−) button, and the button aligns to the top of multi-line rows.

### Before

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d116da9b-f148-4e3b-8d88-82d34f0f5ec5" />

### After

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7c224c83-f1f2-4019-9181-14a351b65b9f" />
