### PR TITLE
fix: Prefer `$XDG_CONFIG_HOME` to `$HOME/.config` on Linux

### DIFF
--- a/apps/plumeimpactor/src/defaults.rs
+++ b/apps/plumeimpactor/src/defaults.rs
@@ -61,7 +61,9 @@ pub fn get_data_path() -> PathBuf {
     let base = if cfg!(windows) {
         env::var("APPDATA").unwrap()
     } else {
-        env::var("HOME").unwrap() + "/.config"
+        env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+            env::var("HOME").unwrap() + "/.config"
+        })
     };
 
     let dir = Path::new(&base).join("PlumeImpactor");

--- a/apps/plumesign/src/main.rs
+++ b/apps/plumesign/src/main.rs
@@ -28,7 +28,9 @@ pub fn get_data_path() -> PathBuf {
     let base = if cfg!(windows) {
         env::var("APPDATA").unwrap()
     } else {
-        env::var("HOME").unwrap() + "/.config"
+        env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+            env::var("HOME").unwrap() + "/.config"
+        })
     };
 
     let dir = Path::new(&base).join("PlumeImpactor");


### PR DESCRIPTION
Flatpak apps should store config to `$XDG_CONFIG_HOME` according to [Flatpak docs](https://docs.flatpak.org/en/latest/conventions.html#xdg-base-directories).

Current implementation uses `$HOME/.config`, which is on tmpfs in Flatpak by default if no host directory access is granted (according to [Flatpak docs](https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access)). Such in the case, PlumeImpactor would lost config after restart.

Use `$XDG_CONFIG_HOME`, which is persistent in Flatpak sandboxes, fall back to `$HOME/.config` if the former does not exist.

Fixes: #153

A quick fix for current Flatpak users is `flatpak override --user --persist=.config dev.khcrysalis.PlumeImpactor`, which maps `.var/app/dev.khcrysalis.PlumeImpactor/.config` to `$HOME/.config` so to make it persistent.