### PR TITLE
Support tvOS IPA installation

### DIFF
--- a/apps/plumeimpactor/src/refresh.rs
+++ b/apps/plumeimpactor/src/refresh.rs
@@ -171,13 +171,17 @@ impl RefreshDaemon {
             .get_account(&refresh_device.account)
             .ok_or_else(|| format!("Account {} not found", refresh_device.account))?;
 
-        let session = DeveloperSession::new(
+        let mut session = DeveloperSession::new(
             account.adsid().clone(),
             account.xcode_gs_token().clone(),
             AnisetteConfiguration::default().set_configuration_path(get_data_path()),
         )
         .await
         .map_err(|e| format!("Failed to create session: {}", e))?;
+
+        if device.is_tvos {
+            session.platform = "tvos".to_string();
+        }
 
         let teams_response = session
             .qh_list_teams()
@@ -263,7 +267,7 @@ impl RefreshDaemon {
     ) -> Result<(), String> {
         let team_id_string = team_id.to_string();
         session
-            .qh_ensure_device(&team_id_string, &device.name, &device.udid)
+            .qh_ensure_device(&team_id_string, &device.name, &device.udid, device.is_tvos)
             .await
             .map_err(|e| format!("Failed to ensure device: {}", e))?;
 
@@ -272,6 +276,7 @@ impl RefreshDaemon {
 
         let options = SignerOptions {
             mode: SignerMode::Pem,
+            is_tvos: device.is_tvos,
             ..Default::default()
         };
 
@@ -291,7 +296,7 @@ impl RefreshDaemon {
         let mut signer = Signer::new(Some(signing_identity), options);
 
         signer
-            .register_bundle(&bundle, session, &team_id.to_string(), true)
+            .register_bundle(&bundle, session, &team_id.to_string(), true, device.is_tvos)
             .await
             .map_err(|e| format!("Failed to register bundle: {}", e))?;
 
@@ -321,18 +326,25 @@ impl RefreshDaemon {
         session: &DeveloperSession,
         team_id: &str,
     ) -> Result<(), String> {
+        let team_id_string = team_id.to_string();
+        session
+            .qh_ensure_device(&team_id_string, &device.name, &device.udid, device.is_tvos)
+            .await
+            .map_err(|e| format!("Failed to ensure device: {}", e))?;
+
         let bundle =
             Bundle::new(app.path.clone()).map_err(|e| format!("Failed to create bundle: {}", e))?;
 
         let options = SignerOptions {
             mode: SignerMode::Pem,
+            is_tvos: device.is_tvos,
             ..Default::default()
         };
 
         let mut signer = Signer::new(None, options);
 
         signer
-            .register_bundle(&bundle, session, &team_id.to_string(), true)
+            .register_bundle(&bundle, session, &team_id.to_string(), true, device.is_tvos)
             .await
             .map_err(|e| format!("Failed to register bundle: {}", e))?;
 

--- a/apps/plumeimpactor/src/subscriptions.rs
+++ b/apps/plumeimpactor/src/subscriptions.rs
@@ -33,6 +33,7 @@ pub(crate) fn device_listener() -> Subscription<Message> {
                                     device_id: u32::MAX,
                                     usbmuxd_device: None,
                                     is_mac: true,
+                                    is_tvos: false,
                                 }));
                             }
                         }
@@ -301,7 +302,7 @@ pub(crate) async fn run_installation(
 
             send("Ensuring account is valid...".to_string(), 20);
 
-            let session = DeveloperSession::new(
+            let mut session = DeveloperSession::new(
                 account.adsid().clone(),
                 account.xcode_gs_token().clone(),
                 AnisetteConfiguration::default()
@@ -348,12 +349,18 @@ pub(crate) async fn run_installation(
 
             send("Ensuring device is registered...".to_string(), 30);
 
+            let is_tvos = device.as_ref().is_some_and(|d| d.is_tvos);
             if let Some(dev) = &device {
+                if dev.is_tvos {
+                    session.platform = "tvos".to_string();
+                }
                 session
-                    .qh_ensure_device(team_id, &dev.name, &dev.udid)
+                    .qh_ensure_device(team_id, &dev.name, &dev.udid, dev.is_tvos)
                     .await
                     .map_err(|e| e.to_string())?;
             }
+
+            options.is_tvos = is_tvos;
 
             send("Extracting package...".to_string(), 50);
 
@@ -368,7 +375,7 @@ pub(crate) async fn run_installation(
                 .await
                 .map_err(|e| e.to_string())?;
             signer
-                .register_bundle(&bundle, &session, team_id, false)
+                .register_bundle(&bundle, &session, team_id, false, is_tvos)
                 .await
                 .map_err(|e| e.to_string())?;
             signer

--- a/apps/plumesign/src/commands/account.rs
+++ b/apps/plumesign/src/commands/account.rs
@@ -275,7 +275,7 @@ async fn devices(args: DevicesArgs) -> Result<()> {
 }
 
 async fn register_device(args: RegisterDeviceArgs) -> Result<()> {
-    let session = get_authenticated_account().await?;
+    let mut session = get_authenticated_account().await?;
 
     let team_id = if args.team_id.is_none() {
         teams(&session).await?
@@ -283,8 +283,15 @@ async fn register_device(args: RegisterDeviceArgs) -> Result<()> {
         args.team_id.unwrap()
     };
 
+    let is_tvos = args.udid.starts_with("AppleTV");
+
+    // Default to tvos if the device UDID matches tvOS pattern
+    if is_tvos {
+        session.platform = "tvos".to_string();
+    }
+
     let p = session
-        .qh_add_device(&team_id, &args.name, &args.udid)
+        .qh_add_device(&team_id, &args.name, &args.udid, is_tvos)
         .await?
         .device;
 

--- a/apps/plumesign/src/commands/device.rs
+++ b/apps/plumesign/src/commands/device.rs
@@ -56,6 +56,7 @@ pub async fn execute(args: DeviceArgs) -> Result<()> {
                     device_id: 0,
                     usbmuxd_device: None,
                     is_mac: true,
+                    is_tvos: false,
                 }
             } else {
                 select_device(args.udid).await?

--- a/apps/plumesign/src/commands/sign.rs
+++ b/apps/plumesign/src/commands/sign.rs
@@ -54,6 +54,9 @@ pub struct SignArgs {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     #[arg(short = 'm', long = "mac", value_name = "MAC", conflicts_with = "udid")]
     pub mac: bool,
+    /// Platform to target (ios, tvos). Defaults to ios.
+    #[arg(long = "platform", value_name = "PLATFORM", default_value = "ios")]
+    pub platform: String,
 }
 
 pub async fn execute(args: SignArgs) -> Result<()> {
@@ -91,7 +94,8 @@ pub async fn execute(args: SignArgs) -> Result<()> {
         options.mode = SignerMode::Pem;
         (Signer::new(Some(cert_identity), options), None)
     } else if args.apple_id {
-        let session = get_authenticated_account().await?;
+        let mut session = get_authenticated_account().await?;
+        session.platform = args.platform.clone();
         let team_id = teams(&session).await?;
         let cert_identity = CertificateIdentity::new_with_session(
             &session,
@@ -130,6 +134,7 @@ pub async fn execute(args: SignArgs) -> Result<()> {
                     device_id: 0,
                     usbmuxd_device: None,
                     is_mac: true,
+                    is_tvos: false,
                 })
             } else {
                 Some(select_device(args.udid).await?)
@@ -148,15 +153,18 @@ pub async fn execute(args: SignArgs) -> Result<()> {
             .modify_bundle(&bundle, &Some(team_id.clone()))
             .await?;
 
+        let mut is_tvos = false;
+
         if let Some(ref dev) = device {
             log::info!("Registering device: {} ({})", dev.name, dev.udid);
+            is_tvos = dev.is_tvos;
             session
-                .qh_ensure_device(&team_id, &dev.name, &dev.udid)
+                .qh_ensure_device(&team_id, &dev.name, &dev.udid, dev.is_tvos)
                 .await?;
         }
 
         signer
-            .register_bundle(&bundle, &session, &team_id, false)
+            .register_bundle(&bundle, &session, &team_id, false, is_tvos)
             .await?;
         signer.sign_bundle(&bundle).await?;
 

--- a/crates/plume_core/src/developer/qh/devices.rs
+++ b/crates/plume_core/src/developer/qh/devices.rs
@@ -24,6 +24,7 @@ impl DeveloperSession {
         team_id: &String,
         device_name: &String,
         device_udid: &String,
+        is_tvos: bool,
     ) -> Result<DeviceResponse, Error> {
         let endpoint = developer_endpoint!("/QH65B2/ios/addDevice.action");
 
@@ -34,6 +35,16 @@ impl DeveloperSession {
             "deviceNumber".to_string(),
             Value::String(device_udid.clone()),
         );
+        if is_tvos {
+            body.insert(
+                "DTDK_Platform".to_string(),
+                Value::String("tvos".to_string()),
+            );
+            body.insert(
+                "subPlatform".to_string(),
+                Value::String("tvOS".to_string()),
+            );
+        }
 
         let response = self.qh_send_request(&endpoint, Some(body)).await?;
         let response_data: DeviceResponse = plist::from_value(&Value::Dictionary(response))?;
@@ -61,12 +72,13 @@ impl DeveloperSession {
         team_id: &String,
         device_name: &String,
         device_udid: &String,
+        is_tvos: bool,
     ) -> Result<Device, Error> {
         if let Some(device) = self.qh_get_device(team_id, device_udid).await? {
             Ok(device)
         } else {
             let response = self
-                .qh_add_device(team_id, device_name, device_udid)
+                .qh_add_device(team_id, device_name, device_udid, is_tvos)
                 .await?;
             Ok(response.device)
         }

--- a/crates/plume_core/src/developer/qh/profile.rs
+++ b/crates/plume_core/src/developer/qh/profile.rs
@@ -11,12 +11,24 @@ impl DeveloperSession {
         &self,
         team_id: &String,
         app_id_id: &String,
+        is_tvos: bool,
     ) -> Result<ProfilesResponse, Error> {
         let endpoint = developer_endpoint!("/QH65B2/ios/downloadTeamProvisioningProfile.action");
 
         let mut body = Dictionary::new();
         body.insert("teamId".to_string(), Value::String(team_id.clone()));
         body.insert("appIdId".to_string(), Value::String(app_id_id.clone()));
+
+        if is_tvos {
+            body.insert(
+                "DTDK_Platform".to_string(),
+                Value::String("tvos".to_string()),
+            );
+            body.insert(
+                "subPlatform".to_string(),
+                Value::String("tvOS".to_string()),
+            );
+        }
 
         let response = self.qh_send_request(&endpoint, Some(body)).await?;
         let response_data: ProfilesResponse = plist::from_value(&Value::Dictionary(response))?;

--- a/crates/plume_core/src/developer/session.rs
+++ b/crates/plume_core/src/developer/session.rs
@@ -21,6 +21,7 @@ pub struct DeveloperSession {
     client: Client,
     adsid: String,          // from grandslam's SPD "adsid"
     xcode_gs_token: String, // requested from spd initially // com.apple.gs.xcode.auth
+    pub platform: String,   // "ios" or "tvos"
 }
 
 impl DeveloperSession {
@@ -43,6 +44,7 @@ impl DeveloperSession {
             client: account.client.clone(),
             adsid: adsid.into(),
             xcode_gs_token,
+            platform: "ios".to_string(),
         })
     }
 
@@ -67,6 +69,7 @@ impl DeveloperSession {
             client,
             adsid,
             xcode_gs_token,
+            platform: "ios".to_string(),
         };
 
         // we test the session by listing teams

--- a/crates/plume_core/src/developer/v1/capabilities.rs
+++ b/crates/plume_core/src/developer/v1/capabilities.rs
@@ -24,9 +24,10 @@ impl DeveloperSession {
     pub async fn v1_list_capabilities(&self, team: &String) -> Result<CapabilitiesResponse, Error> {
         let endpoint = developer_endpoint!("/v1/capabilities");
 
+        let platform_filter = if self.platform == "tvos" { "TV_OS" } else { "IOS" };
         let body = json!({
             "teamId": team,
-            "urlEncodedQueryParams": "filter[platform]=IOS"
+            "urlEncodedQueryParams": format!("filter[platform]={}", platform_filter)
         });
 
         let response = self

--- a/crates/plume_utils/src/device.rs
+++ b/crates/plume_utils/src/device.rs
@@ -44,11 +44,12 @@ pub struct Device {
     // On x86_64 macs, `is_mac` variable should never be true
     // since its only true if the device is added manually.
     pub is_mac: bool,
+    pub is_tvos: bool,
 }
 
 impl Device {
     pub async fn new(usbmuxd_device: UsbmuxdDevice) -> Self {
-        let name = Self::get_name_from_usbmuxd_device(&usbmuxd_device)
+        let (name, is_tvos) = Self::get_name_and_platform_from_usbmuxd_device(&usbmuxd_device)
             .await
             .unwrap_or_default();
 
@@ -58,15 +59,21 @@ impl Device {
             device_id: usbmuxd_device.device_id.clone(),
             usbmuxd_device: Some(usbmuxd_device),
             is_mac: false,
+            is_tvos,
         }
     }
 
-    async fn get_name_from_usbmuxd_device(device: &UsbmuxdDevice) -> Result<String, Error> {
+    async fn get_name_and_platform_from_usbmuxd_device(
+        device: &UsbmuxdDevice,
+    ) -> Result<(String, bool), Error> {
         let mut lockdown =
             LockdownClient::connect(&device.to_provider(UsbmuxdAddr::default(), CONNECTION_LABEL))
                 .await?;
         let values = lockdown.get_value(None, None).await?;
-        Ok(get_dict_string!(values, "DeviceName"))
+        let name = get_dict_string!(values, "DeviceName");
+        let product_type = get_dict_string!(values, "ProductType");
+        let is_tvos = product_type.starts_with("AppleTV");
+        Ok((name, is_tvos))
     }
 
     pub async fn installed_apps(&self) -> Result<Vec<SignerAppReal>, Error> {

--- a/crates/plume_utils/src/options.rs
+++ b/crates/plume_utils/src/options.rs
@@ -26,6 +26,8 @@ pub struct SignerOptions {
     pub app: SignerApp,
     /// Apply autorefresh
     pub refresh: bool,
+    /// tvOS target
+    pub is_tvos: bool,
 }
 
 impl Default for SignerOptions {
@@ -43,6 +45,7 @@ impl Default for SignerOptions {
             tweaks: None,
             app: SignerApp::Default,
             refresh: false,
+            is_tvos: false,
         }
     }
 }

--- a/crates/plume_utils/src/signer.rs
+++ b/crates/plume_utils/src/signer.rs
@@ -50,15 +50,16 @@ impl Signer {
         }
 
         if self.options.features.support_minimum_os_version {
-            bundle.set_info_plist_key("MinimumOSVersion", "7.0")?;
+            let min_os = if self.options.is_tvos { "13.0" } else { "7.0" };
+            bundle.set_info_plist_key("MinimumOSVersion", min_os)?;
         }
 
-        if self.options.features.support_file_sharing {
+        if !self.options.is_tvos && self.options.features.support_file_sharing {
             bundle.set_info_plist_key("UIFileSharingEnabled", true)?;
             bundle.set_info_plist_key("UISupportsDocumentBrowser", true)?;
         }
 
-        if self.options.features.support_ipad_fullscreen {
+        if !self.options.is_tvos && self.options.features.support_ipad_fullscreen {
             bundle.set_info_plist_key("UIRequiresFullScreen", true)?;
         }
 
@@ -66,7 +67,7 @@ impl Signer {
             bundle.set_info_plist_key("GCSupportsGameMode", true)?;
         }
 
-        if self.options.features.support_pro_motion {
+        if !self.options.is_tvos && self.options.features.support_pro_motion {
             bundle.set_info_plist_key("CADisableMinimumFrameDurationOnPhone", true)?;
         }
 
@@ -187,12 +188,14 @@ impl Signer {
             });
 
             bundle.set_info_plist_key("CFBundleIcons", cf_bundle_icons)?;
-            bundle.set_info_plist_key("CFBundleIcons~ipad", cf_bundle_icons_ipad)?;
+            if !self.options.is_tvos {
+                bundle.set_info_plist_key("CFBundleIcons~ipad", cf_bundle_icons_ipad)?;
+            }
         }
 
         let has_tweaks = self.options.tweaks.as_ref().is_some_and(|t| !t.is_empty());
 
-        if self.options.features.support_ellekit || has_tweaks {
+        if !self.options.is_tvos && (self.options.features.support_ellekit || has_tweaks) {
             crate::Tweak::install_ellekit(&bundle).await?;
         }
 
@@ -228,6 +231,7 @@ impl Signer {
         session: &DeveloperSession,
         team_id: &String,
         is_refresh: bool,
+        is_tvos: bool,
     ) -> Result<(), Error> {
         if self.options.mode != SignerMode::Pem {
             return Ok(());
@@ -337,7 +341,7 @@ impl Signer {
                 }
 
                 let profiles = session
-                    .qh_get_profile(&team_id, &app_id_id.app_id_id)
+                    .qh_get_profile(&team_id, &app_id_id.app_id_id, is_tvos)
                     .await?;
                 let profile_data = profiles.provisioning_profile.encoded_profile;
 


### PR DESCRIPTION
Impactor can now install IPAs on Apple TV. Previously every API call hardcoded iOS, so tvOS devices registered but were invisible to tvOS profile generation and installs failed with error **8220 "no devices"**.

## What was wrong, and what to fix?

Upstream assumed iOS everywhere. Three things required for IPA tvOS install to work:

1. **Device registration** must tell Apple the device is tvOS (`DTDK_Platform` + `subPlatform`), otherwise Apple tags it as iOS.
2. **Profile download** must send the same tags, otherwise Apple generates an iOS profile, finds no matching iOS device, and returns 8220.
3. **Capabilities** must be requested with the `TV_OS` filter, otherwise the profile is missing tvOS entitlements and the app installs but won't launch.

Everything else is straight forward so those three changes can read the correct platform.

## How

- Detect tvOS from usbmuxd `ProductType` (`AppleTV*`) → `Device.is_tvos`.
- Carry `platform` on `DeveloperSession` (default `ios`) and `is_tvos` on `SignerOptions`.
- Add an `is_tvos` parameter to `qh_add_device`, `qh_ensure_device`, `qh_get_profile`, and `register_bundle` so the platform tags reach the right API calls.
- `modify_bundle` now uses `MinimumOSVersion` `13.0` for tvOS (was `7.0`) and skips iOS-only keys: file sharing, iPad fullscreen, ProMotion, `CFBundleIcons~ipad`, and ellekit `.deb` injection.
- `update_provisioning_profiles` now calls `qh_ensure_device` (it didn't before) — without it, profile refresh hits 8220 on tvOS.
- `plumesign sign` gains `--platform <ios|tvos>` (default `ios`).

A couple of details that are easy to get wrong and can break signing:

- QH URL paths stay `.../QH65B2/ios/...` for **all** platforms. `.../QH65B2/tvos/...` returns 1003 "Service mapping not available." The platform is communicated via the request **body**, not the URL.
- `subPlatform` is capital `OS` (`"tvOS"`); `DTDK_Platform` is lowercase (`"tvos"`). Mismatch and Apple silently ignores the key.
- `options.is_tvos` must be set **before** `Signer::new`, otherwise `modify_bundle` applies iOS modifications to the tvOS IPA.

## Files

- `crates/plume_core/src/developer/qh/devices.rs` — `qh_add_device` / `qh_ensure_device`
- `crates/plume_core/src/developer/qh/profile.rs` — `qh_get_profile`
- `crates/plume_core/src/developer/v1/capabilities.rs` — `TV_OS` filter
- `crates/plume_core/src/developer/session.rs` — `platform` field
- `crates/plume_utils/src/device.rs` — `is_tvos` detection
- `crates/plume_utils/src/options.rs` — `is_tvos` field
- `crates/plume_utils/src/signer.rs` — tvOS-aware `modify_bundle`, threaded `register_bundle`
- `apps/plumeimpactor/src/subscriptions.rs` — install path
- `apps/plumeimpactor/src/refresh.rs` — refresh / reinstall / profile update
- `apps/plumesign/src/commands/sign.rs` — `--platform` flag
- `apps/plumesign/src/commands/account.rs`, `device.rs` — device literals

## Verification

`cargo check --workspace` is clean (no new warnings, only existing ones in `omnisette`/`block`).

Reference: SideStore/AltSign `develop`, `Sources/ALTAppleAPI+Operations.swift`.
[https://github.com/SideStore/AltSign/blob/develop/Sources/ALTAppleAPI+Operations.swift](https://github.com/SideStore/AltSign/blob/develop/Sources/ALTAppleAPI+Operations.swift)