### PR TITLE
fix(build): set DisplayVersion in Windows installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,8 @@ jobs:
           mkdir dist\nsis
           copy package\windows\* dist\nsis\
           copy dist\Impactor-windows-${{ matrix.arch }}-portable.exe dist\nsis\plumeimpactor.exe
-          makensis dist\nsis\installer.nsi
+          $version = (Select-String -Path Cargo.toml -Pattern '^version = "(.+)"$').Matches.Groups[1].Value
+          makensis /DAPPVERSION=$version dist\nsis\installer.nsi
           move dist\nsis\installer.exe dist\Impactor-windows-${{ matrix.arch }}-setup.exe
 
       - name: Upload Installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,8 @@ jobs:
           mkdir dist\nsis
           copy package\windows\* dist\nsis\
           copy dist\Impactor-windows-${{ matrix.arch }}-portable.exe dist\nsis\plumeimpactor.exe
-          makensis dist\nsis\installer.nsi
+          $version = (Select-String -Path Cargo.toml -Pattern '^version = "(.+)"$').Matches.Groups[1].Value
+          makensis /DAPPVERSION=$version dist\nsis\installer.nsi
           move dist\nsis\installer.exe dist\Impactor-windows-${{ matrix.arch }}-setup.exe
 
       - name: Upload Installer

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ windows:
 ifeq ($(NSIS),1)
 	@cp target/$(PROFILE)/plumeimpactor.exe dist/nsis/
 	@cp -r package/windows/* dist/nsis/
-	@makensis dist/nsis/installer.nsi
+	@VERSION=$$(awk '/\[workspace.package\]/,/^$$/' Cargo.toml | sed -nE 's/version *= *"([^"]*)".*/\1/p'); \
+		makensis -DAPPVERSION=$$VERSION dist/nsis/installer.nsi
 	@mv dist/nsis/installer.exe dist/Impactor-$(SUFFIX)-setup.exe
 endif
 

--- a/package/windows/installer.nsi
+++ b/package/windows/installer.nsi
@@ -6,6 +6,10 @@
 !define APPEXE  "plumeimpactor.exe"
 !define COMPANY "Samara"
 
+!ifndef APPVERSION
+    !error "APPVERSION must be defined when building the installer"
+!endif
+
 Name "${APPNAME}"
 BrandingText "${APPNAME} Setup"
 
@@ -60,6 +64,7 @@ Section "Install"
 
     ; 64-bit registry uninstall entry
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayVersion" "${APPVERSION}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "Publisher" "${COMPANY}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$INSTDIR"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$INSTDIR\Uninstall.exe"


### PR DESCRIPTION
## Summary

- pass the workspace version from `Cargo.toml` to NSIS in the Makefile and GitHub build/release workflows
- write that version to the Windows uninstall registry entry as `DisplayVersion`
- fail the NSIS build when `APPVERSION` is not provided

## Testing

- [x] Built Windows binaries for x86, x86_64, and ARM64 with the fork's `Build & Bundle` workflow
- [x] Built NSIS installers for all three Windows architectures
- [x] Installed the x86_64 artifact built with a temporary workspace version of `2.6.1`
- [x] Verified `HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\PlumeImpactor\DisplayVersion` changed to `2.6.1`
- [x] Verified `winget list --id CLARATION.Impactor.GUI --exact` reported version `2.6.1`

Test run: https://github.com/pgs666/Impactor/actions/runs/29953531068

The overall workflow run reports a failure because the existing macOS `Setup osxcross` job failed; all Windows build and installer jobs completed successfully.

Fixes #219