### PR TITLE
feat(tweaks): configurable injection path and optional tweak loader

### DIFF
--- a/apps/plumesign/src/commands/macho.rs
+++ b/apps/plumesign/src/commands/macho.rs
@@ -16,6 +16,12 @@ pub struct MachArgs {
     /// Add a dylib dependency (e.g., @rpath/MyLib.dylib)
     #[arg(long, value_name = "DYLIB_PATH")]
     pub add_dylib: Option<String>,
+    /// List all LC_RPATH search paths
+    #[arg(long)]
+    pub list_rpaths: bool,
+    /// Add an LC_RPATH search path
+    #[arg(long, value_name = "RPATH")]
+    pub add_rpath: Option<String>,
     /// Replace an existing dylib dependency
     #[arg(long, value_names = &["OLD", "NEW"], num_args = 2)]
     pub replace_dylib: Option<Vec<String>>,
@@ -29,6 +35,11 @@ pub async fn execute(args: MachArgs) -> Result<()> {
 
     if let Some(dylib_path) = &args.add_dylib {
         macho.add_dylib(dylib_path)?;
+        return Ok(());
+    }
+
+    if let Some(rpath) = &args.add_rpath {
+        macho.add_rpath(rpath)?;
         return Ok(());
     }
 
@@ -48,6 +59,13 @@ pub async fn execute(args: MachArgs) -> Result<()> {
             .dylib_load_paths()
             .unwrap();
         for path in d {
+            println!("{path}");
+        }
+        return Ok(());
+    }
+
+    if args.list_rpaths {
+        for path in macho.rpaths()? {
             println!("{path}");
         }
         return Ok(());

--- a/apps/plumesign/src/commands/sign.rs
+++ b/apps/plumesign/src/commands/sign.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use clap::Args;
 
 use plume_core::{CertificateIdentity, MobileProvision};
-use plume_utils::{Bundle, Package, Signer, SignerMode, SignerOptions};
+use plume_utils::{
+    Bundle, Package, Signer, SignerMode, SignerOptions, TweakInjectFolder, TweakInjectPath,
+    TweakInjection, TweakLoader,
+};
 
 use crate::{
     commands::{
@@ -38,9 +41,22 @@ pub struct SignArgs {
     /// Custom bundle version to set
     #[arg(long = "custom-version", value_name = "VERSION")]
     pub version: Option<String>,
-    /// Perform ad-hoc signing (no certificate required)
+    /// Tweak files to apply before signing (.deb, .dylib, .framework, .bundle, .appex)
     #[arg(long, short, num_args = 1..)]
     pub tweaks: Option<Vec<PathBuf>>,
+    /// Loader/runtime to bundle when applying tweaks
+    #[arg(long = "tweak-loader", value_name = "LOADER", default_value_t = TweakLoader::ElleKit)]
+    pub tweak_loader: TweakLoader,
+    /// Load-path prefix for user tweak dylibs/frameworks; supplying this opts into custom injection-path mode
+    #[arg(long = "tweak-inject-path", alias = "inject-path", value_name = "PATH")]
+    pub tweak_inject_path: Option<TweakInjectPath>,
+    /// Load-path folder for user tweak dylibs/frameworks; supplying this opts into custom injection-path mode
+    #[arg(
+        long = "tweak-inject-folder",
+        alias = "inject-folder",
+        value_name = "FOLDER"
+    )]
+    pub tweak_inject_folder: Option<TweakInjectFolder>,
     /// Register device and install after signing
     #[arg(long)]
     pub register_and_install: bool,
@@ -63,11 +79,20 @@ pub async fn execute(args: SignArgs) -> Result<()> {
         ));
     }
 
+    let tweak_injection = match (args.tweak_inject_path, args.tweak_inject_folder) {
+        (None, None) => TweakInjection::Legacy,
+        (path, folder) => {
+            TweakInjection::custom(path.unwrap_or_default(), folder.unwrap_or_default())
+        }
+    };
+
     let mut options = SignerOptions {
         custom_identifier: args.bundle_identifier,
         custom_name: args.name,
         custom_version: args.version,
         tweaks: args.tweaks,
+        tweak_loader: args.tweak_loader,
+        tweak_injection,
         ..Default::default()
     };
 

--- a/crates/plume_core/src/utils/macho.rs
+++ b/crates/plume_core/src/utils/macho.rs
@@ -7,7 +7,7 @@ use goblin::mach::{
     cputype::CPU_TYPE_ARM64,
     load_command::{
         CommandVariant, LC_LAZY_LOAD_DYLIB, LC_LOAD_DYLIB, LC_LOAD_UPWARD_DYLIB,
-        LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB,
+        LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB, LC_RPATH,
     },
 };
 use plist::{Dictionary, Value};
@@ -82,6 +82,23 @@ impl MachO {
         Ok(())
     }
 
+    pub fn rpaths(&self) -> Result<Vec<String>, Error> {
+        let mut out = Vec::new();
+        for macho in self.macho_file.iter_macho() {
+            out.extend(macho.rpath_load_paths()?);
+        }
+        Ok(out)
+    }
+
+    pub fn add_rpath(&mut self, path: &str) -> Result<(), Error> {
+        let machos = self.macho_file.iter_macho_mut();
+        for macho in machos {
+            macho.add_rpath_load_path(path)?;
+        }
+        self.write_changes()?;
+        Ok(())
+    }
+
     pub fn replace_dylib(&mut self, old_path: &str, new_path: &str) -> Result<(), Error> {
         let machos = self.macho_file.iter_macho_mut();
         for macho in machos {
@@ -114,7 +131,9 @@ impl MachO {
 pub trait MachOExt {
     fn embedded_entitlements(&self) -> Result<Option<Dictionary>, Error>;
     fn dylib_load_paths(&self) -> Result<Vec<String>, Error>;
+    fn rpath_load_paths(&self) -> Result<Vec<String>, Error>;
     fn add_dylib_load_path(&mut self, path: &str) -> Result<(), Error>;
+    fn add_rpath_load_path(&mut self, path: &str) -> Result<(), Error>;
     fn remove_dylib_load_path(&mut self, path: &str) -> Result<(), Error>;
     fn replace_dylib_load_path(&mut self, old_path: &str, new_path: &str) -> Result<(), Error>;
     fn replace_sdk_version(&mut self, new_version: &str) -> Result<(), Error>;
@@ -156,6 +175,20 @@ impl<'a> MachOExt for MachOBinary<'a> {
                 };
                 if let Some(p) = path {
                     paths.push(p);
+                }
+            }
+        }
+
+        Ok(paths)
+    }
+
+    fn rpath_load_paths(&self) -> Result<Vec<String>, Error> {
+        let mut paths = Vec::new();
+
+        for load_cmd in &self.macho.load_commands {
+            if load_cmd.command.cmd() == LC_RPATH {
+                if let Some(path) = manually_parse_lc_str(self.data, load_cmd.offset, 8) {
+                    paths.push(path);
                 }
             }
         }
@@ -278,6 +311,91 @@ impl<'a> MachOExt for MachOBinary<'a> {
         data[sizeofcmds_offset..sizeofcmds_offset + 4]
             .copy_from_slice(&new_sizeofcmds.to_le_bytes());
         data[ncmds_offset..ncmds_offset + 4].copy_from_slice(&new_ncmds.to_le_bytes());
+
+        self.data = Box::leak(data.into_boxed_slice());
+
+        Ok(())
+    }
+
+    fn add_rpath_load_path(&mut self, path: &str) -> Result<(), Error> {
+        let macho = &self.macho;
+
+        let read_u32_le = |data: &[u8], offset: usize| -> u32 {
+            u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ])
+        };
+
+        let rpath_exists = macho.load_commands.iter().any(|load_cmd| {
+            load_cmd.command.cmd() == LC_RPATH
+                && manually_parse_lc_str(self.data, load_cmd.offset, 8)
+                    .map_or(false, |existing| existing == path)
+        });
+
+        if rpath_exists {
+            log::warn!("RPath already exists in binary: {}", path);
+            return Ok(());
+        }
+
+        let is_64 = matches!(macho.header.cputype, CPU_TYPE_ARM64);
+        let current_sizeofcmds = read_u32_le(&self.data, 20);
+        let current_ncmds = read_u32_le(&self.data, 16);
+
+        let mut data = self.data.to_vec();
+
+        let header_size = if is_64 { 32 } else { 28 };
+        let rpath_len = path.len();
+        let padding = (8 - ((rpath_len + 1) % 8)) % 8;
+        let command_size = 12 + rpath_len + 1 + padding;
+
+        let load_commands_offset = header_size;
+        let load_commands_end = load_commands_offset + current_sizeofcmds as usize;
+
+        let min_fileoff = macho
+            .load_commands
+            .iter()
+            .filter_map(|load_cmd| match &load_cmd.command {
+                CommandVariant::Segment64(seg) if seg.filesize > 0 && seg.fileoff > 0 => {
+                    Some(seg.fileoff)
+                }
+                CommandVariant::Segment32(seg) if seg.filesize > 0 && seg.fileoff > 0 => {
+                    Some(seg.fileoff as u64)
+                }
+                _ => None,
+            })
+            .min()
+            .unwrap_or(u64::MAX);
+
+        let data_start = if min_fileoff < u64::MAX {
+            min_fileoff as usize
+        } else {
+            data.len()
+        };
+
+        let available_space = data_start.saturating_sub(load_commands_end);
+        if command_size > available_space {
+            return Err(Error::Parse);
+        }
+
+        let insert_offset = load_commands_end;
+        let mut new_command = Vec::new();
+        new_command.extend_from_slice(&(LC_RPATH as u32).to_le_bytes());
+        new_command.extend_from_slice(&(command_size as u32).to_le_bytes());
+        new_command.extend_from_slice(&12u32.to_le_bytes());
+        new_command.extend_from_slice(path.as_bytes());
+        new_command.push(0);
+        new_command.extend(vec![0u8; padding]);
+
+        data[insert_offset..insert_offset + command_size].copy_from_slice(&new_command);
+
+        let new_sizeofcmds = current_sizeofcmds + command_size as u32;
+        let new_ncmds = current_ncmds + 1;
+
+        data[20..24].copy_from_slice(&new_sizeofcmds.to_le_bytes());
+        data[16..20].copy_from_slice(&new_ncmds.to_le_bytes());
 
         self.data = Box::leak(data.into_boxed_slice());
 
@@ -490,18 +608,26 @@ fn extract_dylib_path(
         .map(|s| s.to_string())
 }
 
-// TODO: our custom ones need manual parsing?
-fn manually_parse_dylib(file_data: &[u8], load_cmd_offset: usize) -> Option<String> {
-    if load_cmd_offset + 12 > file_data.len() {
+fn manually_parse_lc_str(
+    file_data: &[u8],
+    load_cmd_offset: usize,
+    offset_field: usize,
+) -> Option<String> {
+    if load_cmd_offset + offset_field + 4 > file_data.len() {
         return None;
     }
 
     let name_offset_field = u32::from_le_bytes([
-        file_data[load_cmd_offset + 8],
-        file_data[load_cmd_offset + 9],
-        file_data[load_cmd_offset + 10],
-        file_data[load_cmd_offset + 11],
+        file_data[load_cmd_offset + offset_field],
+        file_data[load_cmd_offset + offset_field + 1],
+        file_data[load_cmd_offset + offset_field + 2],
+        file_data[load_cmd_offset + offset_field + 3],
     ]);
 
     extract_dylib_path(file_data, load_cmd_offset, name_offset_field)
+}
+
+// TODO: our custom ones need manual parsing?
+fn manually_parse_dylib(file_data: &[u8], load_cmd_offset: usize) -> Option<String> {
+    manually_parse_lc_str(file_data, load_cmd_offset, 8)
 }

--- a/crates/plume_utils/src/lib.rs
+++ b/crates/plume_utils/src/lib.rs
@@ -18,6 +18,10 @@ pub use options::{
     SignerInstallMode, // Installation mode
     SignerMode,        // Signing mode
     SignerOptions,     // Main
+    TweakInjectFolder,
+    TweakInjectPath,
+    TweakInjection,
+    TweakLoader,
 };
 pub use package::Package; // Package helper
 pub use signer::Signer; // Signer

--- a/crates/plume_utils/src/options.rs
+++ b/crates/plume_utils/src/options.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 /// Settings for the signer process.
 #[derive(Clone, Debug)]
@@ -22,6 +22,10 @@ pub struct SignerOptions {
     pub install_mode: SignerInstallMode,
     /// Tweaks to apply before signing.
     pub tweaks: Option<Vec<PathBuf>>,
+    /// Loader/runtime to bundle when applying tweaks.
+    pub tweak_loader: TweakLoader,
+    /// User tweak load-path behavior.
+    pub tweak_injection: TweakInjection,
     /// App type.
     pub app: SignerApp,
     /// Apply autorefresh
@@ -41,6 +45,8 @@ impl Default for SignerOptions {
             mode: SignerMode::default(),
             install_mode: SignerInstallMode::default(),
             tweaks: None,
+            tweak_loader: TweakLoader::default(),
+            tweak_injection: TweakInjection::default(),
             app: SignerApp::Default,
             refresh: false,
         }
@@ -81,6 +87,197 @@ pub struct SignerFeatures {
 #[derive(Clone, Debug, Default)]
 pub struct SignerEmbedding {
     pub single_profile: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweakLoader {
+    /// Bundle and inject the bundled ElleKit/CydiaSubstrate compatibility framework.
+    ElleKit,
+    /// Do not bundle a tweak loader. User tweak dylibs/frameworks are still copied and injected.
+    None,
+}
+
+impl Default for TweakLoader {
+    fn default() -> Self {
+        TweakLoader::ElleKit
+    }
+}
+
+impl std::fmt::Display for TweakLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TweakLoader::ElleKit => write!(f, "ellekit"),
+            TweakLoader::None => write!(f, "none"),
+        }
+    }
+}
+
+impl FromStr for TweakLoader {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "ellekit" => Ok(TweakLoader::ElleKit),
+            "none" | "nothing" | "direct" => Ok(TweakLoader::None),
+            other => Err(format!(
+                "unsupported tweak loader '{other}', expected one of: ellekit, none"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweakInjectPath {
+    ExecutablePath,
+    RPath,
+}
+
+impl Default for TweakInjectPath {
+    fn default() -> Self {
+        TweakInjectPath::RPath
+    }
+}
+
+impl TweakInjectPath {
+    pub fn token(self) -> &'static str {
+        match self {
+            TweakInjectPath::ExecutablePath => "@executable_path",
+            TweakInjectPath::RPath => "@rpath",
+        }
+    }
+}
+
+impl std::fmt::Display for TweakInjectPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.token())
+    }
+}
+
+impl FromStr for TweakInjectPath {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "@rpath" | "rpath" => Ok(TweakInjectPath::RPath),
+            "@executable_path" | "executable" | "executable_path" | "executable-path" | "exec" => {
+                Ok(TweakInjectPath::ExecutablePath)
+            }
+            other => Err(format!(
+                "unsupported tweak inject path '{other}', expected @rpath or @executable_path"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweakInjectFolder {
+    Root,
+    Frameworks,
+}
+
+impl Default for TweakInjectFolder {
+    fn default() -> Self {
+        TweakInjectFolder::Root
+    }
+}
+
+impl TweakInjectFolder {
+    pub fn load_path_component(self) -> &'static str {
+        match self {
+            TweakInjectFolder::Root => "",
+            TweakInjectFolder::Frameworks => "Frameworks/",
+        }
+    }
+}
+
+impl std::fmt::Display for TweakInjectFolder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TweakInjectFolder::Root => write!(f, "/"),
+            TweakInjectFolder::Frameworks => write!(f, "Frameworks/"),
+        }
+    }
+}
+
+impl FromStr for TweakInjectFolder {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "" | "/" | "." | "root" => Ok(TweakInjectFolder::Root),
+            "framework" | "frameworks" | "frameworks/" | "/frameworks" | "/frameworks/" => {
+                Ok(TweakInjectFolder::Frameworks)
+            }
+            other => Err(format!(
+                "unsupported tweak inject folder '{other}', expected / or Frameworks/"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TweakInjection {
+    /// Existing behavior: copy dylibs/frameworks into Frameworks and inject @rpath/<leaf>.
+    Legacy,
+    /// Explicit UI-compatible path/folder mode.
+    Custom {
+        path: TweakInjectPath,
+        folder: TweakInjectFolder,
+    },
+}
+
+impl Default for TweakInjection {
+    fn default() -> Self {
+        TweakInjection::Legacy
+    }
+}
+
+impl TweakInjection {
+    pub fn custom(path: TweakInjectPath, folder: TweakInjectFolder) -> Self {
+        TweakInjection::Custom { path, folder }
+    }
+
+    pub fn destination_dir(self, app_bundle: &std::path::Path) -> PathBuf {
+        match self {
+            TweakInjection::Legacy => app_bundle.join("Frameworks"),
+            TweakInjection::Custom { folder, .. } => match folder {
+                TweakInjectFolder::Root => app_bundle.to_path_buf(),
+                TweakInjectFolder::Frameworks => app_bundle.join("Frameworks"),
+            },
+        }
+    }
+
+    pub fn dylib_load_path(self, file_name: &str) -> String {
+        match self {
+            TweakInjection::Legacy => format!("@rpath/{file_name}"),
+            TweakInjection::Custom { path, folder } => format!(
+                "{}/{folder}{file_name}",
+                path.token(),
+                folder = folder.load_path_component()
+            ),
+        }
+    }
+
+    pub fn framework_load_path(self, framework_name: &str, executable_name: &str) -> String {
+        match self {
+            TweakInjection::Legacy => format!("@rpath/{framework_name}/{executable_name}"),
+            TweakInjection::Custom { path, folder } => format!(
+                "{}/{folder}{framework_name}/{executable_name}",
+                path.token(),
+                folder = folder.load_path_component()
+            ),
+        }
+    }
+
+    pub fn required_rpath(self) -> Option<&'static str> {
+        match self {
+            TweakInjection::Custom {
+                path: TweakInjectPath::RPath,
+                ..
+            } => Some("@executable_path"),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/plume_utils/src/signer.rs
+++ b/crates/plume_utils/src/signer.rs
@@ -9,7 +9,9 @@ use plume_core::{
     developer::DeveloperSession,
 };
 
-use crate::{Bundle, BundleType, Error, PlistInfoTrait, SignerApp, SignerMode, SignerOptions};
+use crate::{
+    Bundle, BundleType, Error, PlistInfoTrait, SignerApp, SignerMode, SignerOptions, TweakLoader,
+};
 
 pub struct Signer {
     certificate: Option<CertificateIdentity>,
@@ -192,13 +194,21 @@ impl Signer {
 
         let has_tweaks = self.options.tweaks.as_ref().is_some_and(|t| !t.is_empty());
 
-        if self.options.features.support_ellekit || has_tweaks {
+        if self.options.tweak_loader == TweakLoader::ElleKit
+            && (self.options.features.support_ellekit || has_tweaks)
+        {
             crate::Tweak::install_ellekit(&bundle).await?;
         }
 
         if let Some(tweak_files) = self.options.tweaks.as_ref() {
             for tweak_file in tweak_files {
-                let tweak = crate::Tweak::new(tweak_file, bundle).await?;
+                let tweak = crate::Tweak::new_with_options(
+                    tweak_file,
+                    bundle,
+                    self.options.tweak_loader,
+                    self.options.tweak_injection,
+                )
+                .await?;
                 tweak.apply().await?;
             }
         }

--- a/crates/plume_utils/src/tweak.rs
+++ b/crates/plume_utils/src/tweak.rs
@@ -6,7 +6,7 @@ use std::{
 use plume_core::MachO;
 use uuid::Uuid;
 
-use crate::{Bundle, Error, PlistInfoTrait, copy_dir_recursively};
+use crate::{Bundle, Error, PlistInfoTrait, TweakInjection, TweakLoader, copy_dir_recursively};
 
 const ELLEKIT_BYTES: &[u8] = include_bytes!("./ellekit.deb");
 
@@ -14,6 +14,8 @@ pub struct Tweak {
     path: PathBuf,
     app_bundle: PathBuf,
     stage_dir: PathBuf,
+    loader: TweakLoader,
+    injection: TweakInjection,
 }
 
 impl Tweak {
@@ -24,7 +26,13 @@ impl Tweak {
         let deb_path = stage_dir.join("ellekit.deb");
         tokio::fs::write(&deb_path, ELLEKIT_BYTES).await?;
 
-        let tweak = Tweak::new(&deb_path, app_bundle).await?;
+        let tweak = Tweak::new_with_options(
+            &deb_path,
+            app_bundle,
+            TweakLoader::ElleKit,
+            TweakInjection::Legacy,
+        )
+        .await?;
         tweak.install_deb().await?;
 
         tokio::fs::remove_dir_all(&stage_dir).await.ok();
@@ -33,6 +41,29 @@ impl Tweak {
     }
 
     pub async fn new<P: AsRef<Path>>(tweak_path: P, app_bundle: &Bundle) -> Result<Self, Error> {
+        Self::new_with_options(
+            tweak_path,
+            app_bundle,
+            TweakLoader::ElleKit,
+            TweakInjection::Legacy,
+        )
+        .await
+    }
+
+    pub async fn new_with_loader<P: AsRef<Path>>(
+        tweak_path: P,
+        app_bundle: &Bundle,
+        loader: TweakLoader,
+    ) -> Result<Self, Error> {
+        Self::new_with_options(tweak_path, app_bundle, loader, TweakInjection::Legacy).await
+    }
+
+    pub async fn new_with_options<P: AsRef<Path>>(
+        tweak_path: P,
+        app_bundle: &Bundle,
+        loader: TweakLoader,
+        injection: TweakInjection,
+    ) -> Result<Self, Error> {
         let path = tweak_path.as_ref();
         if !path.exists() {
             return Err(Error::TweakInvalidPath);
@@ -59,6 +90,8 @@ impl Tweak {
             path: path.to_path_buf(),
             app_bundle: app_bundle.bundle_dir().clone(),
             stage_dir,
+            loader,
+            injection,
         })
     }
 
@@ -217,33 +250,45 @@ impl Tweak {
     }
 
     async fn install_dylib(&self, dylib_path: &Path) -> Result<(), Error> {
-        let frameworks_dir = self.app_bundle.join("Frameworks");
-        tokio::fs::create_dir_all(&frameworks_dir).await?;
+        let install_dir = self.injection.destination_dir(&self.app_bundle);
+        tokio::fs::create_dir_all(&install_dir).await?;
 
         let dylib_name = dylib_path.file_name().ok_or(Error::TweakInvalidPath)?;
-        let dest = frameworks_dir.join(dylib_name);
+        let dylib_name_str = dylib_name.to_str().ok_or(Error::TweakInvalidPath)?;
+        let dest = install_dir.join(dylib_name);
 
         tokio::fs::copy(dylib_path, &dest).await?;
 
-        Self::patch_cydiasubstrate(&dest);
-        self.inject_dylib(&dest, false).await
+        if self.loader == TweakLoader::ElleKit {
+            Self::patch_cydiasubstrate(&dest);
+        }
+
+        let load_path = self.injection.dylib_load_path(dylib_name_str);
+        self.inject_load_path(&load_path).await
     }
 
     async fn install_framework(&self, framework_path: &Path) -> Result<(), Error> {
-        let frameworks_dir = self.app_bundle.join("Frameworks");
-        tokio::fs::create_dir_all(&frameworks_dir).await?;
+        let install_dir = self.injection.destination_dir(&self.app_bundle);
+        tokio::fs::create_dir_all(&install_dir).await?;
 
         let framework_name = framework_path.file_name().ok_or(Error::TweakInvalidPath)?;
-        let dest = frameworks_dir.join(framework_name);
+        let framework_name_str = framework_name.to_str().ok_or(Error::TweakInvalidPath)?;
+        let dest = install_dir.join(framework_name);
 
         copy_dir_recursively(&framework_path, &dest).await?;
 
         if let Ok(bundle) = Bundle::new(&dest) {
             if let Some(exec_name) = bundle.get_executable() {
-                let exec_path = dest.join(exec_name);
+                let exec_path = dest.join(&exec_name);
                 if exec_path.exists() {
-                    Self::patch_cydiasubstrate(&exec_path);
-                    self.inject_dylib(&exec_path, true).await?;
+                    if self.loader == TweakLoader::ElleKit {
+                        Self::patch_cydiasubstrate(&exec_path);
+                    }
+
+                    let load_path = self
+                        .injection
+                        .framework_load_path(framework_name_str, &exec_name);
+                    self.inject_load_path(&load_path).await?;
                 }
             }
         }
@@ -268,7 +313,7 @@ impl Tweak {
         copy_dir_recursively(appex_path, &dest).await
     }
 
-    async fn inject_dylib(&self, dylib_path: &Path, is_framework: bool) -> Result<(), Error> {
+    async fn inject_load_path(&self, load_path: &str) -> Result<(), Error> {
         let bundle = Bundle::new(&self.app_bundle)?;
         let executable_name = bundle
             .get_executable()
@@ -279,30 +324,14 @@ impl Tweak {
             return Err(Error::BundleInfoPlistMissing);
         }
 
-        let inject_path = if is_framework {
-            let components: Vec<_> = dylib_path.components().rev().take(2).collect();
-            format!(
-                "@rpath/{}/{}",
-                components[1]
-                    .as_os_str()
-                    .to_str()
-                    .ok_or(Error::TweakInvalidPath)?,
-                components[0]
-                    .as_os_str()
-                    .to_str()
-                    .ok_or(Error::TweakInvalidPath)?
-            )
-        } else {
-            let file_name = dylib_path
-                .file_name()
-                .and_then(|f| f.to_str())
-                .ok_or(Error::TweakInvalidPath)?;
-            format!("@rpath/{}", file_name)
-        };
+        if let Some(rpath) = self.injection.required_rpath() {
+            let mut macho = MachO::new(&executable_path)?;
+            macho.add_rpath(rpath)?;
+        }
 
+        // Re-parse after adding LC_RPATH so LC_LOAD_DYLIB insertion sees the updated header.
         let mut macho = MachO::new(&executable_path)?;
-        macho.add_dylib(&inject_path)?;
-        macho.write_changes()?;
+        macho.add_dylib(load_path)?;
 
         Ok(())
     }


### PR DESCRIPTION
Adds control over two things that were previously hardcoded when applying tweaks: which loader gets bundled, and where user tweak dylibs/frameworks land and are loaded from.

## Tweak loader

New `--tweak-loader <ellekit|none>` on `plumesign sign` (default `ellekit`, i.e. current behavior).

- `ellekit` — unchanged: the bundled ElleKit/CydiaSubstrate compatibility deb is installed and `CydiaSubstrate` references in tweaks are patched to point at it.
- `none` — nothing is bundled. User tweak dylibs/frameworks are still copied in and injected, but no loader deb is installed and no CydiaSubstrate patching happens. This is what you want for tweaks that link nothing (or ship their own hooking), and for tweaks meant to run against a substitute/substrate already present on the target.

`SignerOptions::tweak_loader` carries this, so it's usable from the library too.

## Injection path

Two new flags, both opt-in — if neither is passed, behavior is byte-for-byte the old one (copy into `Frameworks/`, inject `@rpath/<leaf>`):

- `--tweak-inject-path <@rpath|@executable_path>` (default `@rpath`)
- `--tweak-inject-folder </|Frameworks/>` (default `/`)

Passing either switches to explicit mode, where the destination directory and the `LC_LOAD_DYLIB` string are derived from the pair — e.g. `@executable_path` + `/` copies the dylib next to the executable and injects `@executable_path/MyTweak.dylib`; `@rpath` + `Frameworks/` injects `@rpath/Frameworks/MyTweak.dylib`. Frameworks resolve their executable from the inner Info.plist and get the same treatment.

When `@rpath` is selected in explicit mode, an `LC_RPATH` of `@executable_path` is added to the app executable first so the load path actually resolves.

## Mach-O support

Needed for the above:

- `MachO::rpaths()` / `MachO::add_rpath()`, with `LC_RPATH` insertion done in place in the load-command padding (errors out rather than corrupting the binary if there isn't room).
- `plumesign macho --list-rpaths` and `--add-rpath <RPATH>` to drive those from the CLI.
- The manual `lc_str` parser is generalised to take the offset-field position instead of assuming 8, since `LC_RPATH` and `LC_LOAD_DYLIB` both need it.
- Dylib injection no longer double-writes: `add_dylib` already flushes, so the redundant `write_changes()` call after it is gone.

## Compatibility

Defaults are unchanged everywhere. `Tweak::new()` keeps its signature and maps to ellekit + legacy injection; `new_with_loader()` / `new_with_options()` are the new entry points.
