### PR TITLE
fix(settings): stop the team picker from squeezing the account list

### DIFF
--- a/apps/plumeimpactor/src/screen/settings.rs
+++ b/apps/plumeimpactor/src/screen/settings.rs
@@ -168,7 +168,10 @@ impl SettingsScreen {
                         })
                         .placeholder(placeholder)
                         .on_open(Message::FetchTeams(email.to_string()))
-                        .style(appearance::s_pick_list);
+                        .style(appearance::s_pick_list)
+                        // Share the row evenly with the account button; otherwise a long
+                        // team name would grow the picker and squeeze the account list.
+                        .width(Fill);
 
                         account_row = account_row.push(team_pick);
                     }


### PR DESCRIPTION
### What

The team picker in the settings screen used the default `Shrink` width. Once the teams finished loading, the picker resized itself to fit the full team name (e.g. `Company Name (TEAMID)`), which ate the row and left almost no space for the account button next to it — the account email ended up wrapped into a narrow column.

This also meant the row jumped around: the picker was narrow while it only showed the team ID placeholder, then suddenly grew wide once the names arrived.

### How

Give the picker `Fill` as well, so it shares the row evenly with the account button and its width no longer depends on the length of the loaded team name.

```rust
.style(appearance::s_pick_list)
// Share the row evenly with the account button; otherwise a long
// team name would grow the picker and squeeze the account list.
.width(Fill);
```

### Screenshots

Before:

<img width="1150" height="950" alt="image" src="https://github.com/user-attachments/assets/07dff008-9049-4455-a62d-862054b45bde" />


After:

<img width="1150" height="950" alt="image" src="https://github.com/user-attachments/assets/09264c7a-598d-40ba-a79c-3d4387ab1bfd" />


### Testing

- `cargo check -p plumeimpactor` / `cargo build --bin plumeimpactor` (macOS, aarch64) — clean.
- Ran the GUI locally and checked the settings screen with an account whose team name is long (`Chengdu iSlide Network Technology Co., Ltd. (…)`); the account button keeps its half of the row and no longer resizes when the teams finish loading.
