### PR TITLE
fix: tls handshake eof (maybe)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "rustls",
     "gzip",
+    "system-proxy",
 ] }
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
closes #129

im not really sure what causes this error because there's nothing online about it, apparently it has something to do with proxies or vpns, it happens in my rust discord bot which uses reqwest, adding `system-proxy` feature to reqwest seems to fix it